### PR TITLE
Add docs on PYTHIA_DATASET_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ To add a new dataset file, please follow these steps:
   In [6]: df = pd.read_csv(filepath)
   ```
 
+## Changing the default data cache location
+
+The default cache location (where the data are saved on your local system) is dependent on the operating system. You can use the `locate()` method to identify it:
+
+```python
+from pythia_datasets import locate
+locate()
+```
+
+The location can be overwritten by the `PYTHIA_DATASETS_DIR` environment
+variable to the desired destination.  
+
+
 [github-ci-badge]: https://img.shields.io/github/workflow/status/ProjectPythia/pythia-datasets/CI?label=CI&logo=github&style=for-the-badge
 [github-lint-badge]: https://img.shields.io/github/workflow/status/ProjectPythia/pythia-datasets/linting?label=linting&logo=github&style=for-the-badge
 [github-ci-link]: https://github.com/ProjectPythia/pythia-datasets/actions?query=workflow%3ACI

--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ locate()
 ```
 
 The location can be overwritten by the `PYTHIA_DATASETS_DIR` environment
-variable to the desired destination.  
-
+variable to the desired destination.
 
 [github-ci-badge]: https://img.shields.io/github/workflow/status/ProjectPythia/pythia-datasets/CI?label=CI&logo=github&style=for-the-badge
 [github-lint-badge]: https://img.shields.io/github/workflow/status/ProjectPythia/pythia-datasets/linting?label=linting&logo=github&style=for-the-badge


### PR DESCRIPTION
Closes https://github.com/ProjectPythia/pythia-foundations/issues/143 by adding info to the README for the pythia-datasets repo on how to specify a custom data cache location.