### PR TITLE
FIX: Fix the mamba-forge failing CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           channels: conda-forge
-          mamba-version: '*'
+          miniforge-variant: Mambaforge
           activate-environment: pythia-datasets
           auto-update-conda: false
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This fixes our mamba forge configuration which should resolve the failing CI.
